### PR TITLE
Remove potentially misleading message

### DIFF
--- a/__tests__/integration/api-integration.test.js
+++ b/__tests__/integration/api-integration.test.js
@@ -16,7 +16,6 @@ beforeAll(async () => {
     if (isUsingEphemeralStack) {
         console.log(`Starting cloudformation deployment of stack ${stackName}`)
         const { stdout } = await exec(`./deploy.sh ${stackName}`)
-        console.log('Deployment finished')
         console.log(stdout)
     }
     else {


### PR DESCRIPTION
Integration test is calling an external process to deploy an ephemeral environment. Deployment finished message may appear in the build log before the deployment is actually completed. 

Here is how it looks in the CodeBuild logs.

```

  console.log __tests__/integration/api-integration.test.js:19
    Deployment finished
  console.log __tests__/integration/api-integration.test.js:20
    Deploying stack coffee-store-ci-20201011-130015
    Deploying using Cloudformation artifacts bucket cloudformation-artifacts-223200533796-us-east-1
        Deploying with following values
```

Removing `Deployment finished` message may avoid some confusion since Stdout already includes a `stack created/updated` message.